### PR TITLE
Ticket1236 add pv alias

### DIFF
--- a/axisApp/Db/axis.db
+++ b/axisApp/Db/axis.db
@@ -68,11 +68,6 @@ record (transform, "$(P)$(AXIS):INIT")
 	field(CMTA, "Axis initial setpoint")
 }
 
-
-
-
-
-
 #  do not PINI or autosave - underlying motor record will do this
 record(bo, "$(P)$(AXIS):ABLE:SP") {
   field(DESC, "Axis enable")

--- a/axisApp/Db/axis.db
+++ b/axisApp/Db/axis.db
@@ -68,6 +68,11 @@ record (transform, "$(P)$(AXIS):INIT")
 	field(CMTA, "Axis initial setpoint")
 }
 
+
+
+
+
+
 #  do not PINI or autosave - underlying motor record will do this
 record(bo, "$(P)$(AXIS):ABLE:SP") {
   field(DESC, "Axis enable")
@@ -83,6 +88,38 @@ record(bi, "$(P)$(AXIS):ABLE") {
   field(ONAM, "Disable")
 }
 alias("$(P)$(AXIS):ABLE", "$(P)$(AXIS):ABLE:SP:RBV")
+
+# Alternative: have a read/write $(AXIS):MTR_able PV in sync with $(mAXIS)_able
+# This is used in the motor details OPI
+# The $(AXIS):ABLE PVs above are preserved so their functionality is not broken
+record(bo, "$(P)$(AXIS):MTR_able") {
+  field(DESC, "Axis enable")
+  field(OUT, "$(P)$(AXIS)_able_write PP")
+  field(ZNAM, "Enable")
+  field(ONAM, "Disable")
+}
+
+record(bo, "$(P)$(AXIS)_able_write") {
+  field(OUT, "$(P)$(mAXIS)_able PP MS")
+  field(ZNAM, "Enable")
+  field(ONAM, "Disable")
+  field(SDIS, "$(P)$(AXIS)_able_sync.PACT")
+  field(DISV, "1")
+}
+
+record(bi, "$(P)$(AXIS)_able_read") {
+  field(DESC, "Axis enable readback")
+  field(INP, "$(P)$(mAXIS)_able CP MS")
+  field(ZNAM, "Enable")
+  field(ONAM, "Disable")
+  field(FLNK, "$(P)$(AXIS)_able_sync")
+}
+
+record(bo, "$(P)$(AXIS)_able_sync") {
+  field(DOL, "$(P)$(AXIS)_able_read NPP MS")
+  field(OMSL, "closed_loop")
+  field(OUT, "$(P)$(AXIS):MTR_able PP MS")
+}
 
 record(stringin, "$(P)$(AXIS):MOTOR") {
   field(DESC, "Axis motor name")


### PR DESCRIPTION
This was done in the context of ISISComputingGroup/IBEX#1236

While working on that ticket I realised that the motor details OPI expects a PV $(M)_able, which doesn't exist when using the axis aliases, so I've added it here.

To test:
The new :MTR_able PV is read/write and syncs with the _able PV from the motor:
Follow setup as in ISISComputingGroup/ibex_gui#392.
Then open the DMS OPI from the synoptic and drill down to the motor details of one of the axis (this OPI will point at the axis alias PV).
From the motors perspective, drill down to the motor details of the same axis as above (this OPI will point at the actual motor PV).
Try enable/disable the motor in either OPI, and you should see the other OPI being in sync with each other